### PR TITLE
Fix exception in Firefox after paste files

### DIFF
--- a/src/inline-attach.js
+++ b/src/inline-attach.js
@@ -149,11 +149,15 @@
          */
         this.onPaste = function(e) {
             var result = false,
-                clipboardData = e.clipboardData;
+                clipboardData = e.clipboardData,
+                items;
 
-            if (typeof clipboardData === "object" && clipboardData.items !== null) {
-                for (var i = 0; i < clipboardData.items.length; i++) {
-                    var item = clipboardData.items[i];
+            if (typeof clipboardData === "object") {
+
+                items = clipboardData.items || clipboardData.files || [];
+
+                for (var i = 0; i < items.length; i++) {
+                    var item = items[i];
                     if (me.isAllowedFile(item)) {
                         result = true;
                         this.onReceivedFile(item.getAsFile());


### PR DESCRIPTION
This PR tries to fix exceptions from Firefox which doesn't fill the attribute items properly and the access to the property `items` is undefined. The previous check `clipboardData.items !== null` was true and was causing invalid access to the items array.
