### PR TITLE
Add option to send extra headers when sending file

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ All versions can be configured using the following options:
     extraParams: {},
 
     /**
+     * Extra headers which will be send as POST data when sending a file
+     */
+    extraHeaders: {},
+
+    /**
      * When a file is received by drag-drop or paste
      *
      * @param {Blob} file

--- a/src/inline-attach.js
+++ b/src/inline-attach.js
@@ -67,6 +67,16 @@
             }
 
             xhr.open('POST', settings.uploadUrl);
+
+            // Add any available extra headers
+            if (typeof settings.extraHeaders === "object") {
+                for (var header in settings.extraHeaders) {
+                    if (settings.extraHeaders.hasOwnProperty(header)) {
+                        xhr.setRequestHeader(header, settings.extraHeaders[header]);
+                    }
+                }
+            }
+
             xhr.onload = function() {
                 // If HTTP status is OK or Created
                 if (xhr.status === 200 || xhr.status === 201) {
@@ -278,6 +288,11 @@
          * Extra parameters which will be send when uploading a file
          */
         extraParams: {},
+
+        /**
+         * Extra headers which will be send when uploading a file
+         */
+        extraHeaders: {},
 
         /**
          * When a file is received by drag-drop or paste


### PR DESCRIPTION
Sometimes you require some extra headers to be sent when you do the POST request. This PR adds a new `extraHeaders` to be able to do it.
