### PR TITLE
Extended built in uploadFile function

### DIFF
--- a/src/inline-attach.js
+++ b/src/inline-attach.js
@@ -347,7 +347,7 @@
          * @return {Object} containing a parsed version of the response
          *                  or a falsey value will default back to parsing the response as JSON
          */
-        customResponseParser: function(xhr) {
+        customResponseParser: function(xhr) { // jshint unused:false
             return null;
         },
 


### PR DESCRIPTION
Added `uploadMethod` for specifying POST/PUT (default POST)
Added `customResponseParser` to allow server responses to come back in different formats (and get handled nicely)
Added `addFileBeforeExtraParameters` property to allow file to be appended after extra parameters
(Amazon S3 has an issue with the `key` not being the first form data element)

So with the above changes, you can use the plugin to upload directly to S3 using something like:

```
return $('.inlineattach').inlineattach({
    uploadUrl: 'https://my-bucket.s3.amazonaws.com',
    extraParams: {
        key: '${filename}',
        AWSAccessKeyId: '<my S3 access key>,
        acl: 'public-read',  // optional depending on how the S3 buckets are configured
        policy: '<my base64 encoded S3 upload policy>',
        signature: '<my encoded policy signature>',
        success_action_status: '201'
    },
    addFileBeforeExtraParameters: false,
    customResponseParser: function(xhr) {
        return {
            filename: $(xhr.responseXML).find('Location').text()
        };
    }
});
```

See http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html for examples on how to generate the policy and signature
