### PR TITLE
Add settings.setupFormData

### DIFF
--- a/src/inline-attachment.js
+++ b/src/inline-attachment.js
@@ -234,7 +234,12 @@
       }
     }
 
-    formData.append(settings.uploadFieldName, file, "image-" + Date.now() + "." + extension);
+    var remoteFilename = "image-" + Date.now() + "." + extension;
+    if (typeof settings.remoteFilename === 'function') {
+      remoteFilename = settings.remoteFilename(file);
+    }
+
+    formData.append(settings.uploadFieldName, file, remoteFilename);
 
     // Append the extra parameters to the formdata
     if (typeof settings.extraParams === "object") {

--- a/src/inline-attachment.js
+++ b/src/inline-attachment.js
@@ -221,6 +221,10 @@
       settings = this.settings,
       extension = settings.defualtExtension;
 
+    if (typeof settings.setupFormData === 'function') {
+      settings.setupFormData(formData, file);
+    }
+
     // Attach the file. If coming from clipboard, add a default filename (only works in Chrome for now)
     // http://stackoverflow.com/questions/6664967/how-to-give-a-blob-uploaded-as-formdata-a-file-name
     if (file.name) {

--- a/src/inline-attachment.js
+++ b/src/inline-attachment.js
@@ -344,6 +344,8 @@
       }
     }
 
+    if (result) { e.preventDefault(); }
+
     return result;
   };
 


### PR DESCRIPTION
**1. Added `settings.setupFormData`**

Currently `settings.extraParams` appends more fields to the end, after the file itself (which would be very far down the http post payload). pickier server like [S3 direct file upload](https://aws.amazon.com/articles/1434) requires the other fields be in front in order to validate (and reject the upload) - **so i need to augment the `FormData` at the start**

But simply copying values over isn't enough, since some extra params are extracted from the file itself, e.g. `Content-Type` in S3 direct file upload. So the solution is to have parameters augmented via a function instead, and passing the `file` along.

Optional: with `settings.setupFormData`, we can deprecate `settings.extraParams`

**2. Added `data(`inlineattachment`)` so we can access the `inlineAttachment` instance.**

Ideally I'd use `settings.onFileUploadResponse` to customize how I'd handle the S3 direct upload response and return false.

Unfortunately, we cannot access most things that the default `inlineAttachment.prototype.onFileUploadResponse` has access to e.g. `this.settings.urlText`, `this.filenameTag`, `this.editor`

One approach is to obtain the `inlineAttachment` instance and attach a custom `onFileUploadResponse` function directly on it.