### PR TITLE
Allow all types

### DIFF
--- a/src/inline-attachment.js
+++ b/src/inline-attachment.js
@@ -286,7 +286,11 @@
    * @param {File} clipboard data file
    */
   inlineAttachment.prototype.isFileAllowed = function(file) {
-    return this.settings.allowedTypes.indexOf(file.type) >= 0;
+    if (this.settings.allowedTypes.indexOf('*') === 0){
+      return true;
+    } else {
+      return this.settings.allowedTypes.indexOf(file.type) >= 0;
+    }
   };
 
   /**


### PR DESCRIPTION
Allow users to upload any file type if `allowedTypes` set to `['*']`