### PR TITLE
Call onFileUploaded when the upload was succesful.

### DIFF
--- a/docs/pages/configuration.rst
+++ b/docs/pages/configuration.rst
@@ -88,18 +88,6 @@ onFileUploadError(response)
     :return:
         `Boolean` when false is returned it will prevent default error behavior
 
-onFileUploaded(response)
+onFileUploaded(filename)
 
-    Fires when the upload request has finished
-
-uploadHandler(file)
-
-    Custom upload handler, must return false to prevent default handler.
-    Can be used to send file via custom transport(like socket.io)
-
-    :file:
-        `Blob`
-
-    :return:
-        `Boolean`
-         when false is returned it will prevent default upload behavior
+    Fires when the upload request has finished and the textarea has been updated.

--- a/src/inline-attachment.js
+++ b/src/inline-attachment.js
@@ -308,6 +308,7 @@
         var newValue = this.settings.urlText.replace(this.filenameTag, filename);
         var text = this.editor.getValue().replace(this.lastValue, newValue);
         this.editor.setValue(text);
+        this.settings.onFileUploaded.call(this, filename);
       }
     }
   };


### PR DESCRIPTION
Looks to me like onFileUploaded was not used, and the documentation was out of sync. I needed a post-upload handler, so I figured I'd use the unused handler.