### PR TITLE
display value of settings.errorText upon failure

### DIFF
--- a/src/inline-attachment.js
+++ b/src/inline-attachment.js
@@ -328,7 +328,7 @@
    */
   inlineAttachment.prototype.onFileUploadError = function(xhr) {
     if (this.settings.onFileUploadError.call(this, xhr) !== false) {
-      var text = this.editor.getValue().replace(this.lastValue, "");
+      var text = this.editor.getValue().replace(this.lastValue, this.settings.errorText);
       this.editor.setValue(text);
     }
   };


### PR DESCRIPTION
the value of the errorText attribute in the settings object isn't getting displayed even when the request fails. Is this the intended behavior? We can display it by changing this line

Is display an empty string the intended behavior? If so, were should the error message be displayed?